### PR TITLE
Improve error handling and make site URL dynamic

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build latest brief
         run: |
           latest_brief="$(find content/briefs -name '*.md' | sort | tail -n 1)"
-          python3 scripts/publish_brief.py "$latest_brief" --site-url https://Via333.github.io/marketbrief/
+          python3 scripts/publish_brief.py "$latest_brief" --site-url https://${{ github.repository_owner }}.github.io/marketbrief/
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/scripts/publish_brief.py
+++ b/scripts/publish_brief.py
@@ -355,8 +355,11 @@ def send_feishu(webhook: str, title: str, summary: str, url: str, secret: str = 
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=20) as response:
-        response.read()
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            response.read()
+    except Exception as exc:
+        print(f"Feishu webhook error: {exc}", file=sys.stderr)
 
 
 def git_commit_and_push(message: str) -> None:


### PR DESCRIPTION
## Summary
This PR improves the robustness of the Feishu webhook integration and makes the GitHub Pages URL generation dynamic to support repository forks.

## Key Changes
- **Error handling**: Wrapped the Feishu webhook HTTP request in a try-except block to gracefully handle and log any exceptions instead of failing silently or crashing
- **Dynamic site URL**: Updated the GitHub Actions workflow to use `${{ github.repository_owner }}` instead of hardcoding the username, allowing the workflow to work correctly when the repository is forked

## Implementation Details
- Exceptions from the Feishu webhook are now caught and printed to stderr with a descriptive error message
- The site URL in the workflow now dynamically resolves to the repository owner's GitHub Pages domain, making the build process fork-friendly

https://claude.ai/code/session_01Cn5EsanJWm2GHS5R1NKsm6